### PR TITLE
Create rejected items cycle count

### DIFF
--- a/data/InventoryCycleCountSeedData.xml
+++ b/data/InventoryCycleCountSeedData.xml
@@ -13,4 +13,7 @@
         <authz artifactAuthzId="ICC_API_ADMIN" userGroupId="ADMIN" authzTypeEnumId="AUTHZT_ALWAYS" authzActionEnumId="AUTHZA_ALL"/>
     </artifactGroups>
 
+    <moqui.basic.EnumerationType enumTypeId="CYCLE_COUNT" description="cycle count"/>
+    <moqui.basic.Enumeration enumId="REJ_ITEM_COUNT" description="rejected item cycle count" enumTypeId="CYCLE_COUNT"/>
+
 </entity-facade-xml>

--- a/data/InventoryCycleCountSeedData.xml
+++ b/data/InventoryCycleCountSeedData.xml
@@ -13,6 +13,4 @@
         <authz artifactAuthzId="ICC_API_ADMIN" userGroupId="ADMIN" authzTypeEnumId="AUTHZT_ALWAYS" authzActionEnumId="AUTHZA_ALL"/>
     </artifactGroups>
 
-    <moqui.basic.EnumerationType enumTypeId="CYCLE_COUNT" description="cycle count"/>
-    <moqui.basic.Enumeration enumId="REJ_ITEM_COUNT" description="rejected item cycle count" enumTypeId="CYCLE_COUNT"/>
 </entity-facade-xml>

--- a/data/InventoryCycleCountSeedData.xml
+++ b/data/InventoryCycleCountSeedData.xml
@@ -12,4 +12,7 @@
         <!-- Full permissions for the ADMIN user group -->
         <authz artifactAuthzId="ICC_API_ADMIN" userGroupId="ADMIN" authzTypeEnumId="AUTHZT_ALWAYS" authzActionEnumId="AUTHZA_ALL"/>
     </artifactGroups>
+
+    <moqui.basic.EnumerationType enumTypeId="CYCLE_COUNT" description="cycle count"/>
+    <moqui.basic.Enumeration enumId="REJ_ITEM_COUNT" description="rejected item cycle count" enumTypeId="CYCLE_COUNT"/>
 </entity-facade-xml>

--- a/entity/InventoryCountViewEntities.xml
+++ b/entity/InventoryCountViewEntities.xml
@@ -84,53 +84,6 @@ under the License.
         <alias name="qoh" field="quantityOnHandTotal" entity-alias="II" function="sum"/>
     </view-entity>
 
-    <extend-entity entity-name="ProductFacility" package="org.apache.ofbiz.product.facility">
-        <field name="cycleCountThreshold" type="number-decimal" default="2"/>
-    </extend-entity>
-
-    <view-entity entity-name="LastInventoryReset" package="co.hotwax.warehouse">
-        <member-entity entity-alias="iid" entity-name="InventoryItemDetail">
-            <entity-condition>
-                <econdition field-name="reasonEnumId" value="VAR_EXT_RESET"/>
-                <econdition field-name="reasonEnumId" value="CYCLE_COUNT"/>
-            </entity-condition>
-        </member-entity>
-        <alias name="inventoryItemId" entity-alias="iid"/>
-        <alias name="effectiveDate" entity-alias="iid" function="max"/>
-
-    </view-entity>
-    
-    <view-entity entity-name="RejectedItemsCycleCountView" package="co.hotwax.warehouse">
-        <member-entity entity-alias="IID" entity-name="org.apache.ofbiz.product.inventory.InventoryItemDetail"/>
-        <member-entity entity-alias="LIR" entity-name="co.hotwax.warehouse.LastInventoryReset" join-from-alias="IID">
-            <key-map field-name="inventoryItemId"/>
-            <entity-condition>
-                <econdition entity-alias="IID" field-name="effectiveDate" operator="greater-equals" to-field-name="effectiveDate"/>
-            </entity-condition>
-        </member-entity>
-        <member-entity entity-alias="VR" entity-name="org.apache.ofbiz.product.inventory.VarianceReason">
-            <key-map field-name="reasonEnumId" related="varianceReasonId"/>
-            <entity-condition>
-                <econdition field-name="varianceReasonId" operator="not-equals" value="POS_SALE"/>
-            </entity-condition>
-        </member-entity>
-        <member-entity entity-alias="PF" entity-name="org.apache.ofbiz.product.facility.ProductFacility" join-from-alias="IID">
-            <key-map field-name="inventoryItemId"/>
-        </member-entity>
-        <alias name="inventoryItemId" entity-alias="IID"/>
-        <alias name="facilityId" entity-alias="PF"/>
-        <alias name="productId" entity-alias="PF"/>
-        <alias name="cycleCountThreshold" entity-alias="PF"/>
-        <alias name="availableToPromiseTotal" field="availableToPromiseDiff" entity-alias="IID" function="sum"/>
-        <entity-condition>
-            <having-econditions>
-                <econdition field-name="availableToPromiseTotal"
-                            operator="greater-equals"
-                            to-field-name="cycleCountThreshold" to-entity-alias="PF"/>
-            </having-econditions>
-        </entity-condition>
-    </view-entity>
-
     <view-entity entity-name="InventoryCountImportAndProductStoreFacility" package="co.hotwax.warehouse">
         <member-entity entity-alias="ICI" entity-name="InventoryCountImport"/>
         <member-entity entity-alias="PSF" entity-name="ProductStoreFacility" join-from-alias="ICI">

--- a/entity/InventoryCountViewEntities.xml
+++ b/entity/InventoryCountViewEntities.xml
@@ -84,7 +84,7 @@ under the License.
         <alias name="qoh" field="quantityOnHandTotal" entity-alias="II" function="sum"/>
     </view-entity>
 
-    <view-entity entity-name="InventoryCountImportAndProductStoreFacility" package="co.hotwax.warehouse">
+    <view-entity entity-name="FacilityInventoryCountImportView" package="co.hotwax.warehouse">
         <member-entity entity-alias="ICI" entity-name="InventoryCountImport"/>
         <member-entity entity-alias="PSF" entity-name="ProductStoreFacility" join-from-alias="ICI">
             <key-map field-name="facilityId"/>

--- a/entity/InventoryCountViewEntities.xml
+++ b/entity/InventoryCountViewEntities.xml
@@ -83,4 +83,67 @@ under the License.
         <alias name="facilityId" entity-alias="II"/>
         <alias name="qoh" field="quantityOnHandTotal" entity-alias="II" function="sum"/>
     </view-entity>
+
+    <extend-entity entity-name="ProductFacility" package="org.apache.ofbiz.product.facility">
+        <field name="cycleCountThreshold" type="number-decimal" default="2"/>
+    </extend-entity>
+
+    <view-entity entity-name="LastInventoryReset" package="co.hotwax.warehouse">
+        <member-entity entity-alias="iid" entity-name="InventoryItemDetail">
+            <entity-condition>
+                <econdition field-name="reasonEnumId" value="VAR_EXT_RESET"/>
+                <econdition field-name="reasonEnumId" value="CYCLE_COUNT"/>
+            </entity-condition>
+        </member-entity>
+        <alias name="inventoryItemId" entity-alias="iid"/>
+        <alias name="effectiveDate" entity-alias="iid" function="max"/>
+
+    </view-entity>
+    
+    <view-entity entity-name="RejectedItemsCycleCountView" package="co.hotwax.warehouse">
+        <member-entity entity-alias="IID" entity-name="org.apache.ofbiz.product.inventory.InventoryItemDetail"/>
+        <member-entity entity-alias="LIR" entity-name="co.hotwax.warehouse.LastInventoryReset" join-from-alias="IID">
+            <key-map field-name="inventoryItemId"/>
+            <entity-condition>
+                <econdition entity-alias="IID" field-name="effectiveDate" operator="greater-equals" to-field-name="effectiveDate"/>
+            </entity-condition>
+        </member-entity>
+        <member-entity entity-alias="VR" entity-name="org.apache.ofbiz.product.inventory.VarianceReason">
+            <key-map field-name="reasonEnumId" related="varianceReasonId"/>
+            <entity-condition>
+                <econdition field-name="varianceReasonId" operator="not-equals" value="POS_SALE"/>
+            </entity-condition>
+        </member-entity>
+        <member-entity entity-alias="PF" entity-name="org.apache.ofbiz.product.facility.ProductFacility" join-from-alias="IID">
+            <key-map field-name="inventoryItemId"/>
+        </member-entity>
+        <alias name="inventoryItemId" entity-alias="IID"/>
+        <alias name="facilityId" entity-alias="PF"/>
+        <alias name="productId" entity-alias="PF"/>
+        <alias name="cycleCountThreshold" entity-alias="PF"/>
+        <alias name="availableToPromiseTotal" field="availableToPromiseDiff" entity-alias="IID" function="sum"/>
+        <entity-condition>
+            <having-econditions>
+                <econdition field-name="availableToPromiseTotal"
+                            operator="greater-equals"
+                            to-field-name="cycleCountThreshold" to-entity-alias="PF"/>
+            </having-econditions>
+        </entity-condition>
+    </view-entity>
+
+    <view-entity entity-name="InventoryCountImportAndProductStoreFacility" package="co.hotwax.warehouse">
+        <member-entity entity-alias="ICI" entity-name="InventoryCountImport"/>
+        <member-entity entity-alias="PSF" entity-name="ProductStoreFacility" join-from-alias="ICI">
+            <key-map field-name="facilityId"/>
+        </member-entity>
+        <alias name="inventoryCountImportId" entity-alias="ICI"/>
+        <alias name="countTypeEnumId" entity-alias="ICI"/>
+        <alias name="facilityId" entity-alias="ICI"/>
+        <alias name="statusId" entity-alias="ICI"/>
+        <alias name="productStoreId" entity-alias="PSF"/>
+        <entity-condition>
+            <date-filter entity-alias="PSF"/>
+        </entity-condition>
+    </view-entity>
+
 </entities>

--- a/entity/InventoryCountViewEntities.xml
+++ b/entity/InventoryCountViewEntities.xml
@@ -85,8 +85,8 @@ under the License.
     </view-entity>
 
     <view-entity entity-name="FacilityInventoryCountImportView" package="co.hotwax.warehouse">
-        <member-entity entity-alias="ICI" entity-name="InventoryCountImport"/>
-        <member-entity entity-alias="PSF" entity-name="ProductStoreFacility" join-from-alias="ICI">
+        <member-entity entity-alias="ICI" entity-name="co.hotwax.warehouse.InventoryCountImport"/>
+        <member-entity entity-alias="PSF" entity-name="org.apache.ofbiz.product.store.ProductStoreFacility" join-from-alias="ICI">
             <key-map field-name="facilityId"/>
         </member-entity>
         <alias name="inventoryCountImportId" entity-alias="ICI"/>

--- a/service/co/hotwax/cycleCount/InventoryCountServices.xml
+++ b/service/co/hotwax/cycleCount/InventoryCountServices.xml
@@ -243,7 +243,7 @@
         </actions>
     </service>
 
-    <service verb="approve" noun="InventoryCountImportItem">
+    <service verb="accept" noun="InventoryCountImportItem">
         <in-parameters>
             <parameter name="inventoryCountImportId" required="true"/>
             <parameter name="importItemSeqId" required="true"/>
@@ -291,7 +291,7 @@
 
             <!-- Marking Item as accepted/completed. -->
             <service-call name="update#co.hotwax.warehouse.InventoryCountImportItem" in-map="[inventoryCountImportId:context.inventoryCountImportId, importItemSeqId:context.importItemSeqId, statusId:'INV_COUNT_COMPLETED']"/>
-            <return type="info" message="Inventory Count Import Item Approved."/>
+            <return type="info" message="Inventory Count Import Item Accepted."/>
         </actions>
     </service>
     <service verb="run" noun="RecordCycleCount" type="remote-rest" location="${omsBaseUrl}/api/service/recordInventoryCount?token=${token}" method="post">
@@ -516,4 +516,37 @@
             <set field="inventoryCountImportItem" from="resultItem"/>
         </actions>
     </service>
+
+    <service verb="approve" noun="InventoryCountImport">
+        <in-parameters>
+            <parameter name="enumId" required="false"/>
+            <parameter name="productStoreId" required="false"/>
+        </in-parameters>
+        <actions>
+            <entity-find entity-name="InventoryCountImportAndProductStoreFacility" list="inventoryCounts">
+                <econdition field-name="countTypeEnumId" from="enumId" ignore-if-empty="true"/>
+                <econdition field-name="statusId" value="INV_COUNT_CREATED"/>
+                <econdition field-name="productStoreId" from="productStoreId" ignore-if-empty="true"/>
+            </entity-find>
+            <if condition="inventoryCounts == null || inventoryCounts.size() == 0"><return message="No inventory counts found"/></if>
+            <iterate list="inventoryCounts" entry="inventoryCount">
+                <set field="inventoryCount.statusId" value="INV_COUNT_ASSIGNED"/>
+                <service-call name="update#co.hotwax.warehouse.InventoryCountImport"
+                              in-map="inventoryCountImportId:inventoryCount.inventoryCountImportId,
+                              statusId:inventoryCount.statusId"/>
+                <entity-find entity-name="InventoryCountImportItem" list="inventoryCountItems">
+                    <econdition field-name="inventoryCountImportId" from="inventoryCount.inventoryCountImportId"/>
+                </entity-find>
+                <iterate list="inventoryCountItems" entry="inventoryCountItem">
+                    <set field="inventoryCountItem.statusId" value="INV_COUNT_ASSIGNED"/>
+                    <service-call name="update#co.hotwax.warehouse.InventoryCountImportItem"
+                                  in-map="inventoryCountImportId:inventoryCountItem.inventoryCountImportId,
+                                  importItemSeqId:inventoryCountItem.importItemSeqId,
+                                  statusId:inventoryCountItem.statusId"/>
+                </iterate>
+            </iterate>
+        </actions>
+
+    </service>
+
 </services>

--- a/service/co/hotwax/cycleCount/InventoryCountServices.xml
+++ b/service/co/hotwax/cycleCount/InventoryCountServices.xml
@@ -493,18 +493,18 @@
                               out-map="result"
                 />
                 <set field="inventoryCountImportId" from="result.inventoryCountImportId"/>
-                <else>
-                    <set field="inventoryCountImportId" from="inventoryCount.inventoryCountImportId"/>
-                    <entity-find entity-name="InventoryCountImportItem"
-                                 list="inventoryCountItems">
-                        <econdition field-name="inventoryCountImportId" from="inventoryCountImportId"/>
-                        <econdition field-name="productId" from="productId"/>
-                    </entity-find>
-                    <if condition="inventoryCountItems">
-                        <set field="inventoryCountImportItem" from="inventoryCountItems?.first"/>
-                        <return/>
-                    </if>
-                </else>
+            <else>
+                <set field="inventoryCountImportId" from="inventoryCount.inventoryCountImportId"/>
+                <entity-find entity-name="InventoryCountImportItem"
+                             list="inventoryCountItems">
+                    <econdition field-name="inventoryCountImportId" from="inventoryCountImportId"/>
+                    <econdition field-name="productId" from="productId"/>
+                </entity-find>
+                <if condition="inventoryCountItems">
+                    <set field="inventoryCountImportItem" from="inventoryCountItems?.first"/>
+                    <return/>
+                </if>
+            </else>
             </if>
             <service-call name="create#co.hotwax.warehouse.InventoryCountImportItem"
                           in-map="[inventoryCountImportId : inventoryCountImportId,

--- a/service/co/hotwax/cycleCount/InventoryCountServices.xml
+++ b/service/co/hotwax/cycleCount/InventoryCountServices.xml
@@ -495,12 +495,13 @@
                 <set field="inventoryCountImportId" from="result.inventoryCountImportId"/>
                 <else>
                     <set field="inventoryCountImportId" from="inventoryCount.inventoryCountImportId"/>
-                    <entity-find-one entity-name="InventoryCountImportItem" value-field="inventoryCountItem">
-                        <field-map field-name="inventoryCountImportId" from="inventoryCountImportId"/>
-                        <field-map field-name="productId" from="productId"/>
-                    </entity-find-one>
-                    <if condition="inventoryCountItem">
-                        <set field="inventoryCountImportItem" from="inventoryCountItem"/>
+                    <entity-find entity-name="InventoryCountImportItem"
+                                 list="inventoryCountItems">
+                        <econdition field-name="inventoryCountImportId" from="inventoryCountImportId"/>
+                        <econdition field-name="productId" from="productId"/>
+                    </entity-find>
+                    <if condition="inventoryCountItems">
+                        <set field="inventoryCountImportItem" from="inventoryCountItems?.first"/>
                         <return/>
                     </if>
                 </else>
@@ -523,7 +524,7 @@
             <parameter name="productStoreId" required="false"/>
         </in-parameters>
         <actions>
-            <entity-find entity-name="InventoryCountImportAndProductStoreFacility" list="inventoryCounts">
+            <entity-find entity-name="FacilityInventoryCountImportView" list="inventoryCounts">
                 <econdition field-name="countTypeEnumId" from="countTypeEnumId" ignore-if-empty="true"/>
                 <econdition field-name="statusId" value="INV_COUNT_CREATED"/>
                 <econdition field-name="productStoreId" from="productStoreId" ignore-if-empty="true"/>

--- a/service/co/hotwax/cycleCount/InventoryCountServices.xml
+++ b/service/co/hotwax/cycleCount/InventoryCountServices.xml
@@ -467,4 +467,53 @@
             <set field="csvData" from="ec.resource.getLocationReference(systemMessage.messageText).getText()"/>
         </actions>
     </service>
+    
+    <service verb="findOrCreate" noun="RejectedItemCycleCount">
+        <in-parameters>
+            <parameter name="productId" required="true"/>
+            <parameter name="facilityId" required="true"/>
+        </in-parameters>
+        <out-parameters>
+            <parameter name="inventoryCountImportItem" type="Map"/>
+        </out-parameters>
+        <actions>
+            <entity-find-one entity-name="InventoryCountImport" value-field="inventoryCount">
+                <field-map field-name="countTypeEnumId" value="REJ_ITEM_COUNT"/>
+                <field-map field-name="statusId" value="INV_COUNT_CREATED"/>
+                <field-map field-name="facilityId" from="facilityId"/>
+            </entity-find-one>
+            <if condition="!inventoryCount">
+                <service-call name="create#co.hotwax.warehouse.InventoryCountImport"
+                              in-map="[countImportName: 'Rejected Item Count',
+                              countTypeEnumId : 'REJ_ITEM_COUNT',
+                              facilityId : facilityId,
+                              statusId : 'INV_COUNT_CREATED',
+                              uploadedByUserLogin: ec.user.getUsername(),
+                              createdDate: ec.user.nowTimestamp]"
+                              out-map="result"
+                />
+                <set field="inventoryCountImportId" from="result.inventoryCountImportId"/>
+                <else>
+                    <set field="inventoryCountImportId" from="inventoryCount.inventoryCountImportId"/>
+                    <entity-find-one entity-name="InventoryCountImportItem" value-field="inventoryCountItem">
+                        <field-map field-name="inventoryCountImportId" from="inventoryCountImportId"/>
+                        <field-map field-name="productId" from="productId"/>
+                    </entity-find-one>
+                    <if condition="inventoryCountItem">
+                        <set field="inventoryCountImportItem" from="inventoryCountItem"/>
+                        <return/>
+                    </if>
+                </else>
+            </if>
+            <service-call name="create#co.hotwax.warehouse.InventoryCountImportItem"
+                          in-map="[inventoryCountImportId : inventoryCountImportId,
+                          statusId : 'INV_COUNT_CREATED',
+                          productId : productId,
+                          uploadedByUserLogin: ec.user.getUsername(),
+                          createdDate: ec.user.nowTimestamp]"
+                          out-map="resultItem"
+            />
+            <set field="inventoryCountImportItem" from="resultItem"/>
+        </actions>
+    </service>
 </services>

--- a/service/co/hotwax/cycleCount/InventoryCountServices.xml
+++ b/service/co/hotwax/cycleCount/InventoryCountServices.xml
@@ -519,12 +519,12 @@
 
     <service verb="approve" noun="InventoryCountImport">
         <in-parameters>
-            <parameter name="enumId" required="false"/>
+            <parameter name="countTypeEnumId" required="false"/>
             <parameter name="productStoreId" required="false"/>
         </in-parameters>
         <actions>
             <entity-find entity-name="InventoryCountImportAndProductStoreFacility" list="inventoryCounts">
-                <econdition field-name="countTypeEnumId" from="enumId" ignore-if-empty="true"/>
+                <econdition field-name="countTypeEnumId" from="countTypeEnumId" ignore-if-empty="true"/>
                 <econdition field-name="statusId" value="INV_COUNT_CREATED"/>
                 <econdition field-name="productStoreId" from="productStoreId" ignore-if-empty="true"/>
             </entity-find>
@@ -546,7 +546,6 @@
                 </iterate>
             </iterate>
         </actions>
-
     </service>
 
 </services>

--- a/service/inventorycount.rest.xml
+++ b/service/inventorycount.rest.xml
@@ -50,7 +50,7 @@
     <resource name="cycleCounts">
         <method type="get"><entity name="co.hotwax.warehouse.InventoryCountImportView" operation="list"/></method>
         <method type="post"><entity name="co.hotwax.warehouse.InventoryCountImport" operation="create"/></method>
-        <resource name="rejectedItemsCycleCount">
+        <resource name="rejectedItems">
             <method type="post">
                 <service name="co.hotwax.cycleCount.InventoryCountServices.findOrCreate#RejectedItemCycleCount"/>
             </method>
@@ -89,9 +89,9 @@
                     <method type="put"><entity name="co.hotwax.warehouse.InventoryCountImportItem" operation="update"/></method>
                     <method type="delete"><entity name="co.hotwax.warehouse.InventoryCountImportItem" operation="delete"/></method>
 
-                    <resource name="approve">
+                    <resource name="accept">
                         <method type="post">
-                            <service name="co.hotwax.cycleCount.InventoryCountServices.approve#InventoryCountImportItem"/>
+                            <service name="co.hotwax.cycleCount.InventoryCountServices.accept#InventoryCountImportItem"/>
                         </method>
                     </resource>
                 </id>

--- a/service/inventorycount.rest.xml
+++ b/service/inventorycount.rest.xml
@@ -50,6 +50,11 @@
     <resource name="cycleCounts">
         <method type="get"><entity name="co.hotwax.warehouse.InventoryCountImportView" operation="list"/></method>
         <method type="post"><entity name="co.hotwax.warehouse.InventoryCountImport" operation="create"/></method>
+        <resource name="rejectedItemsCycleCount">
+            <method type="post">
+                <service name="co.hotwax.cycleCount.InventoryCountServices.findOrCreate#RejectedItemCycleCount"/>
+            </method>
+        </resource>
         <resource name="bulk">
             <method type="post">
                 <service name="co.hotwax.cycleCount.InventoryCountServices.create#InventoryCountImports"/>

--- a/upgrade/upcoming/upgrade.xml
+++ b/upgrade/upcoming/upgrade.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<entity-facade-xml type="ext-seed">
+    <moqui.basic.EnumerationType enumTypeId="CYCLE_COUNT" description="cycle count"/>
+    <moqui.basic.Enumeration enumId="REJ_ITEM_COUNT" description="rejected item cycle count" enumTypeId="CYCLE_COUNT"/>
+</entity-facade-xml>


### PR DESCRIPTION
Service implementation for rejected item cycle counts. 
- findOrCreate service will search for an existing cycle count and cycle count item, else create a new one for that facilityID and productId. This service is exposed via rest, and called from OMS within the RejectOrderItem service. 
- approve service can be scheduled to automatically approve cycle counts that are in created state, it takes countTypeEnumId and productStoreId as optional input to ensure accurate scheduling. 

