### PR TITLE
Auto accept cycle count

### DIFF
--- a/service/co/hotwax/cycleCount/InventoryCountServices.xml
+++ b/service/co/hotwax/cycleCount/InventoryCountServices.xml
@@ -565,7 +565,7 @@
             <iterate list="inventoryCounts" entry="inventoryCount">
                 <entity-find entity-name="InventoryCountImportItem" list="inventoryCountItems">
                     <econdition field-name="inventoryCountImportId" from="inventoryCount.inventoryCountImportId"/>
-                    <econdition field-name="inventoryCountImportId" value="INV_COUNT_CREATED"/>
+                    <econdition field-name="statusId" value="INV_COUNT_CREATED"/>
                 </entity-find>
                 <set field="numberOfItems" from="inventoryCountItems.size()"/>
                 <iterate list="inventoryCountItems" entry="inventoryCountItem">
@@ -596,7 +596,7 @@
                             systemQOH:qtyOnHand,
                             varianceQty:varianceQty,
                             reason:'CYCLE_COUNT',
-                            comments:'Auto accepted cycle count'"/>
+                            comments:'Auto accepted cycle count'" out-map="result"/>
                     </if>
                 </iterate>
                 <if condition="numberOfItems == 0">

--- a/service/co/hotwax/cycleCount/InventoryCountServices.xml
+++ b/service/co/hotwax/cycleCount/InventoryCountServices.xml
@@ -586,7 +586,7 @@
                         <service-call name="co.hotwax.cycleCount.InventoryCountServices.accept#InventoryCountImportItem"
                             in-map="inventoryCountImportId:inventoryCountItem.inventoryCountImportId,
                             importItemSeqId:inventoryCountItem.importItemSeqId,
-                            quantity:importItemSeqId.quantity,
+                            quantity:inventoryCountItem.quantity,
                             systemQOH:qtyOnHand,
                             varianceQty:varianceQty,
                             reason:'CYCLE_COUNT',

--- a/service/co/hotwax/cycleCount/InventoryCountServices.xml
+++ b/service/co/hotwax/cycleCount/InventoryCountServices.xml
@@ -581,8 +581,9 @@
                                       in-map="inventoryCountImportId:inventoryCountItem.inventoryCountImportId,
                                       importItemSeqId:inventoryCountItem.importItemSeqId,
                                       quantity:importItemSeqId.quantity,
-                                      systemQOH:qtyOnHand, varianceQty:varianceQty
-                                      reason:'CYCLE_COUNT'
+                                      systemQOH:qtyOnHand,
+                                      varianceQty:varianceQty,
+                                      reason:'CYCLE_COUNT',
                                       comments:'Auto accepted cycle count'"/>
                     </if>
                 </iterate>

--- a/service/co/hotwax/cycleCount/InventoryCountServices.xml
+++ b/service/co/hotwax/cycleCount/InventoryCountServices.xml
@@ -574,7 +574,7 @@
                     <if condition="itemQOH">
                         <set field="qtyOnHand" from="itemQOH?.first?.qoh"/>
                     </if>
-                    <if condition="qtyOnHand='0' &amp;&amp; importItemSeqId.quantity != 0">
+                    <if condition="qtyOnHand='0' &amp;&amp; inventoryCountItem.quantity != 0">
                         <return/>
                     </if>
                     <set field="difference" value="0"/>

--- a/service/co/hotwax/cycleCount/InventoryCountServices.xml
+++ b/service/co/hotwax/cycleCount/InventoryCountServices.xml
@@ -550,4 +550,44 @@
         </actions>
     </service>
 
+    <service verb="bulkAccept" noun="InventoryCountImport">
+        <in-parameters>
+            <parameter name="acceptLimit" required="true" type="Double">
+                <number-range max="100" min="0" message="Value should be between 0 and 100"/>
+            </parameter>
+            <parameter name="productStoreId" required="false"/>
+        </in-parameters>
+        <actions>
+            <entity-find entity-name="FacilityInventoryCountImportView" list="inventoryCounts">
+                <econdition field-name="statusId" value="INV_COUNT_REVIEW"/>
+                <econdition field-name="productStoreId" from="productStoreId" ignore-if-empty="true"/>
+            </entity-find>
+            <iterate list="inventoryCounts" entry="inventoryCount">
+                <entity-find entity-name="inventoryCountImportItem" list="inventoryCountItems">
+                    <econdition field-name="inventoryCountImportId" from="inventoryCount.inventoryCountImportId"/>
+                </entity-find>
+                <iterate list="inventoryCountItems" entry="inventoryCountItem">
+                    <entity-find entity-name="co.hotwax.warehouse.InventoryItemSum" list="itemQOH">
+                        <econdition field-name="productId" from="inventoryCount.facilityId"/>
+                        <econdition field-name="facilityId" from="inventoryCountItem.productId"/>
+                    </entity-find>
+                    <if condition="itemQOH">
+                        <set field="qtyOnHand" from="itemQOH?.first?.qoh"/>
+                    </if>
+                    <set field="difference" from="(((qtyOnHand-inventoryCountItem.quantity)/qtyOnHand).abs())*100"/>
+                    <if condition="acceptLimit >= difference">
+                        <set field="varianceQty" from="itemQOH-inventoryCountItem.quantity"/>
+                        <service-call name="co.hotwax.cycleCount.InventoryCountServices.accept#InventoryCountImportItem"
+                                      in-map="inventoryCountImportId:inventoryCountItem.inventoryCountImportId,
+                                      importItemSeqId:inventoryCountItem.importItemSeqId,
+                                      quantity:importItemSeqId.quantity,
+                                      systemQOH:qtyOnHand, varianceQty:varianceQty
+                                      reason:'CYCLE_COUNT'
+                                      comments:'Auto accepted cycle count'"/>
+                    </if>
+                </iterate>
+            </iterate>
+        </actions>
+    </service>
+
 </services>

--- a/service/co/hotwax/cycleCount/InventoryCountServices.xml
+++ b/service/co/hotwax/cycleCount/InventoryCountServices.xml
@@ -563,7 +563,7 @@
                 <econdition field-name="productStoreId" from="productStoreId" ignore-if-empty="true"/>
             </entity-find>
             <iterate list="inventoryCounts" entry="inventoryCount">
-                <entity-find entity-name="inventoryCountImportItem" list="inventoryCountItems">
+                <entity-find entity-name="InventoryCountImportItem" list="inventoryCountItems">
                     <econdition field-name="inventoryCountImportId" from="inventoryCount.inventoryCountImportId"/>
                 </entity-find>
                 <iterate list="inventoryCountItems" entry="inventoryCountItem">
@@ -574,17 +574,23 @@
                     <if condition="itemQOH">
                         <set field="qtyOnHand" from="itemQOH?.first?.qoh"/>
                     </if>
-                    <set field="difference" from="(((qtyOnHand-inventoryCountItem.quantity)/qtyOnHand).abs())*100"/>
+                    <if condition="qtyOnHand='0' &amp;&amp; importItemSeqId.quantity != 0">
+                        <return/>
+                    </if>
+                    <set field="difference" value="0"/>
+                    <if condition="qtyOnHand!='0'">
+                        <set field="difference" from="(((qtyOnHand-inventoryCountItem.quantity)/qtyOnHand).abs())*100"/>
+                    </if>
                     <if condition="acceptLimit >= difference">
                         <set field="varianceQty" from="itemQOH-inventoryCountItem.quantity"/>
                         <service-call name="co.hotwax.cycleCount.InventoryCountServices.accept#InventoryCountImportItem"
-                                      in-map="inventoryCountImportId:inventoryCountItem.inventoryCountImportId,
-                                      importItemSeqId:inventoryCountItem.importItemSeqId,
-                                      quantity:importItemSeqId.quantity,
-                                      systemQOH:qtyOnHand,
-                                      varianceQty:varianceQty,
-                                      reason:'CYCLE_COUNT',
-                                      comments:'Auto accepted cycle count'"/>
+                            in-map="inventoryCountImportId:inventoryCountItem.inventoryCountImportId,
+                            importItemSeqId:inventoryCountItem.importItemSeqId,
+                            quantity:importItemSeqId.quantity,
+                            systemQOH:qtyOnHand,
+                            varianceQty:varianceQty,
+                            reason:'CYCLE_COUNT',
+                            comments:'Auto accepted cycle count'"/>
                     </if>
                 </iterate>
             </iterate>

--- a/service/co/hotwax/cycleCount/InventoryCountServices.xml
+++ b/service/co/hotwax/cycleCount/InventoryCountServices.xml
@@ -565,16 +565,21 @@
             <iterate list="inventoryCounts" entry="inventoryCount">
                 <entity-find entity-name="InventoryCountImportItem" list="inventoryCountItems">
                     <econdition field-name="inventoryCountImportId" from="inventoryCount.inventoryCountImportId"/>
+                    <econdition field-name="inventoryCountImportId" value="INV_COUNT_CREATED"/>
                 </entity-find>
+                <set field="numberOfItems" from="inventoryCountItems.size()"/>
                 <iterate list="inventoryCountItems" entry="inventoryCountItem">
                     <entity-find entity-name="co.hotwax.warehouse.InventoryItemSum" list="itemQOH">
-                        <econdition field-name="productId" from="inventoryCount.facilityId"/>
-                        <econdition field-name="facilityId" from="inventoryCountItem.productId"/>
+                        <econdition field-name="productId" from="inventoryCountItem.productId"/>
+                        <econdition field-name="facilityId" from="inventoryCount.facilityId"/>
                     </entity-find>
                     <if condition="itemQOH">
                         <set field="qtyOnHand" from="itemQOH?.first?.qoh"/>
                     </if>
-                    <if condition="qtyOnHand='0' &amp;&amp; inventoryCountItem.quantity != 0">
+                    <if condition="qtyOnHand == null">
+                        <continue/>
+                    </if>
+                    <if condition="qtyOnHand=='0' &amp;&amp; inventoryCountItem.quantity != 0">
                         <return/>
                     </if>
                     <set field="difference" value="0"/>
@@ -582,7 +587,8 @@
                         <set field="difference" from="(((qtyOnHand-inventoryCountItem.quantity)/qtyOnHand).abs())*100"/>
                     </if>
                     <if condition="acceptLimit >= difference">
-                        <set field="varianceQty" from="itemQOH-inventoryCountItem.quantity"/>
+                        <set field="numberOfItems" from="numberOfItems-1"/>
+                        <set field="varianceQty" from="qtyOnHand-inventoryCountItem.quantity"/>
                         <service-call name="co.hotwax.cycleCount.InventoryCountServices.accept#InventoryCountImportItem"
                             in-map="inventoryCountImportId:inventoryCountItem.inventoryCountImportId,
                             importItemSeqId:inventoryCountItem.importItemSeqId,
@@ -593,6 +599,12 @@
                             comments:'Auto accepted cycle count'"/>
                     </if>
                 </iterate>
+                <if condition="numberOfItems == 0">
+                    <set field="inventoryCount.statusId" value="INV_COUNT_COMPLETED"/>
+                    <service-call name="update#co.hotwax.warehouse.InventoryCountImport"
+                                  in-map="inventoryCountImportId:inventoryCount.inventoryCountImportId,
+                              statusId:inventoryCount.statusId"/>
+                </if>
             </iterate>
         </actions>
     </service>


### PR DESCRIPTION
Implemented configurable threshold-based cycle count acceptance: counts falling within a user-defined variance (e.g., ±10% of on-hand quantity) are automatically approved. Retailers may choose to evaluate tolerances by percentage or absolute difference, and the job will transition to “Completed” once every item is either accepted or cancelled.